### PR TITLE
Ensure apps started

### DIFF
--- a/lib/clickhouse_ecto/storage.ex
+++ b/lib/clickhouse_ecto/storage.ex
@@ -57,6 +57,9 @@ defmodule ClickhouseEcto.Storage do
   end
 
   defp run_query(sql, opts) do
+    {:ok, _} = Application.ensure_all_started(:ecto_sql)
+    {:ok, _} = Application.ensure_all_started(:clickhousex)
+
     opts =
       opts
       |> Keyword.drop([:name, :log, :pool, :pool_size])


### PR DESCRIPTION
## Issue

Erlang: `25.2`
Elixir: `1.14.2`
Phoenix: `1.7.0-rc.0`

Using `ecto_sql 3.9.2` and plausible versions of `clickhousex` / `clickhouse_ecto` on a fresh phoenix 1.7 app

`mix ecto.create` would throw an error: 

```bash
** (Mix) The database for Data.Repo couldn't be created: exited in: GenServer.call(DBConnection.Watcher, {:watch, DBConnection.ConnectionPool.Supervisor, {DBConnection.ConnectionPool.Pool, {#PID<0.354.0>, #Reference<0.2612184000.274071554.55291>, Clickhousex.Protocol, [backoff_type: :stop, database: nil, telemetry_prefix: [:data, :repo], otp_app: :data, timeout: 15000, adapter: ClickhouseEcto, scheme: :http, hostname: "localhost", port: 8123, username: "admin", password: "password", queue_target: 500, queue_interval: 2000, flush_interval_ms: 5000, max_buffer_size: 10000, show_sensitive_data_on_connection_error: true]}}}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
```

## Changes

Looking through `ecto_sql`, noticed that it's ensuring the [deps are started](https://github.com/elixir-ecto/ecto_sql/blob/master/lib/ecto/adapters/postgres.ex#L397-L398)

Added these to the top of `run_query/2` and now the mix tasks are working as expected.  

## Concerns
Not entirely sure what the impact might be on existing apps but [Application.ensure_all_started/2](https://hexdocs.pm/elixir/Application.html#ensure_all_started/2) seems idempotent and safe to call if the deps are started elsewhere. 