### PR TITLE
Use LimitExpr instead of QueryExpr for limit

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ClickhouseEcto.Mixfile do
   def project do
     [
       app: :clickhouse_ecto,
-      version: "0.2.8",
+      version: "0.2.9",
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Six months ago, Ecto added LimitExpr module and now clickhouse_ecto's limit function returns match error.
(FunctionClauseError) no function clause matching in ClickhouseEcto.QueryString.limit/2

I replaced QueryExpr with LimitExpr to avoid the error. 

https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/query.ex